### PR TITLE
Replace radio buttons with checkboxes in settings

### DIFF
--- a/src/components/FlashcardMode1.jsx
+++ b/src/components/FlashcardMode1.jsx
@@ -20,11 +20,11 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }) {
       const r = correct ? 'correct' : 'incorrect'
       setResult(r)
       setHeard(transcripts[0] ?? '')
-      if (settings.feedbackMode === 'voice' || settings.feedbackMode === 'both') {
+      if (settings.feedbackVoice) {
         speak(card.japanese, 'ja-JP')
       }
     },
-    [card, tokenizer, settings.feedbackMode, speak]
+    [card, tokenizer, settings.feedbackVoice, speak]
   )
 
   const { isListening, start, stop } = useSpeechRecognition({
@@ -35,11 +35,11 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }) {
 
   // Auto-start listening on card mount
   useEffect(() => {
-    if (settings.listeningMode !== 'auto' || autoStarted.current) return
+    if (!settings.autoListen || autoStarted.current) return
     autoStarted.current = true
     const timer = setTimeout(() => start(), settings.autoStartDelay)
     return () => clearTimeout(timer)
-  }, [settings.listeningMode, settings.autoStartDelay, start])
+  }, [settings.autoListen, settings.autoStartDelay, start])
 
   // Enforce max listen duration in auto mode
   useEffect(() => {
@@ -57,7 +57,7 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }) {
   }, [result, onAnswer])
 
   const primaryEnglish = Array.isArray(card.english) ? card.english[0] : card.english
-  const showText = settings.feedbackMode === 'text' || settings.feedbackMode === 'both'
+  const showText = settings.feedbackText
 
   return (
     <div className={`flashcard ${result ? `flash-${result}` : ''}`}>
@@ -86,7 +86,7 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }) {
         </div>
       )}
 
-      {result !== null && settings.showTranscript === 'on-result' && heard && (
+      {result !== null && settings.showTranscript && heard && (
         <div className="transcript-heard">Heard: "{heard}"</div>
       )}
 
@@ -96,7 +96,7 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }) {
             isListening={isListening}
             onStart={start}
             onStop={stop}
-            listenMode={settings.listeningMode}
+            listenMode={settings.autoListen ? 'auto' : 'hold'}
           />
           <button className="dont-know-btn" onClick={() => setResult('incorrect')} aria-label="Don't know">
             ?

--- a/src/components/FlashcardMode4.jsx
+++ b/src/components/FlashcardMode4.jsx
@@ -19,7 +19,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }) {
     const timer = setTimeout(() => {
       speak(card.japanese, 'ja-JP', 0.9, () => {
         // onEnd: auto-start listening after the word finishes
-        if (settings.listeningMode === 'auto' && !autoStarted.current) {
+        if (settings.autoListen && !autoStarted.current) {
           autoStarted.current = true
           const startTimer = setTimeout(() => start(), settings.autoStartDelay)
           // can't return cleanup here, but delay is short enough
@@ -33,16 +33,21 @@ export function FlashcardMode4({ card, cardType, onAnswer }) {
 
   const handleResult = useCallback(
     (transcripts) => {
-      const correct = compareEnglish(card.english, transcripts, { phoneticAlgorithm: settings.phoneticAlgorithm })
+      const phoneticAlgorithm =
+        settings.phoneticSoundex && settings.phoneticMetaphone ? 'both'
+        : settings.phoneticSoundex ? 'soundex'
+        : settings.phoneticMetaphone ? 'metaphone'
+        : 'off'
+      const correct = compareEnglish(card.english, transcripts, { phoneticAlgorithm })
       const r = correct ? 'correct' : 'incorrect'
       setResult(r)
       setHeard(transcripts[0] ?? '')
-      if (settings.feedbackMode === 'voice' || settings.feedbackMode === 'both') {
+      if (settings.feedbackVoice) {
         const primaryEnglish = Array.isArray(card.english) ? card.english[0] : card.english
         speak(primaryEnglish, 'en-US')
       }
     },
-    [card, settings.phoneticAlgorithm, settings.feedbackMode, speak]
+    [card, settings.phoneticSoundex, settings.phoneticMetaphone, settings.feedbackVoice, speak]
   )
 
   const { isListening, start, stop } = useSpeechRecognition({
@@ -67,7 +72,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }) {
   }, [result, onAnswer])
 
   const primaryEnglish = Array.isArray(card.english) ? card.english[0] : card.english
-  const showText = settings.feedbackMode === 'text' || settings.feedbackMode === 'both'
+  const showText = settings.feedbackText
 
   return (
     <div className={`flashcard ${result ? `flash-${result}` : ''}`}>
@@ -100,7 +105,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }) {
         </div>
       )}
 
-      {result !== null && settings.showTranscript === 'on-result' && heard && (
+      {result !== null && settings.showTranscript && heard && (
         <div className="transcript-heard">Heard: "{heard}"</div>
       )}
 
@@ -111,7 +116,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }) {
             onStart={start}
             onStop={stop}
             disabled={isSpeaking}
-            listenMode={settings.listeningMode}
+            listenMode={settings.autoListen ? 'auto' : 'hold'}
           />
           <button className="dont-know-btn" onClick={() => setResult('incorrect')} aria-label="Don't know">
             ?

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -8,31 +8,20 @@ export function SettingsPanel() {
     settingsStore.setState({ [key]: value })
   }
 
+  function toggle(key) {
+    settingsStore.setState({ [key]: !settings[key] })
+  }
+
   return (
     <div className="settings-page">
       <section className="settings-section">
         <h3>Listening mode</h3>
         <div className="settings-options">
-          <label className={`settings-option ${settings.listeningMode === 'hold' ? 'active' : ''}`}>
+          <label className={`settings-option ${settings.autoListen ? 'active' : ''}`}>
             <input
-              type="radio"
-              name="listeningMode"
-              value="hold"
-              checked={settings.listeningMode === 'hold'}
-              onChange={() => set('listeningMode', 'hold')}
-            />
-            <div>
-              <strong>Hold to speak</strong>
-              <span>Hold the button while speaking</span>
-            </div>
-          </label>
-          <label className={`settings-option ${settings.listeningMode === 'auto' ? 'active' : ''}`}>
-            <input
-              type="radio"
-              name="listeningMode"
-              value="auto"
-              checked={settings.listeningMode === 'auto'}
-              onChange={() => set('listeningMode', 'auto')}
+              type="checkbox"
+              checked={settings.autoListen}
+              onChange={() => toggle('autoListen')}
             />
             <div>
               <strong>Auto-start</strong>
@@ -42,7 +31,7 @@ export function SettingsPanel() {
         </div>
       </section>
 
-      {settings.listeningMode === 'auto' && (
+      {settings.autoListen && (
         <section className="settings-section">
           <h3>Auto-start delay</h3>
           <div className="settings-slider-row">
@@ -60,7 +49,7 @@ export function SettingsPanel() {
         </section>
       )}
 
-      {settings.listeningMode === 'auto' && (
+      {settings.autoListen && (
         <section className="settings-section">
           <h3>Max listen duration</h3>
           <div className="settings-slider-row">
@@ -83,43 +72,26 @@ export function SettingsPanel() {
       <section className="settings-section">
         <h3>Feedback mode</h3>
         <div className="settings-options">
-          <label className={`settings-option ${settings.feedbackMode === 'text' ? 'active' : ''}`}>
+          <label className={`settings-option ${settings.feedbackText ? 'active' : ''}`}>
             <input
-              type="radio"
-              name="feedbackMode"
-              value="text"
-              checked={settings.feedbackMode === 'text'}
-              onChange={() => set('feedbackMode', 'text')}
+              type="checkbox"
+              checked={settings.feedbackText}
+              onChange={() => toggle('feedbackText')}
             />
             <div>
-              <strong>Text only</strong>
+              <strong>Show text</strong>
               <span>Show the answer on screen</span>
             </div>
           </label>
-          <label className={`settings-option ${settings.feedbackMode === 'voice' ? 'active' : ''}`}>
+          <label className={`settings-option ${settings.feedbackVoice ? 'active' : ''}`}>
             <input
-              type="radio"
-              name="feedbackMode"
-              value="voice"
-              checked={settings.feedbackMode === 'voice'}
-              onChange={() => set('feedbackMode', 'voice')}
+              type="checkbox"
+              checked={settings.feedbackVoice}
+              onChange={() => toggle('feedbackVoice')}
             />
             <div>
-              <strong>Voice only</strong>
+              <strong>Speak answer</strong>
               <span>Speak the answer aloud (good for background use)</span>
-            </div>
-          </label>
-          <label className={`settings-option ${settings.feedbackMode === 'both' ? 'active' : ''}`}>
-            <input
-              type="radio"
-              name="feedbackMode"
-              value="both"
-              checked={settings.feedbackMode === 'both'}
-              onChange={() => set('feedbackMode', 'both')}
-            />
-            <div>
-              <strong>Text and voice</strong>
-              <span>Show and speak the answer</span>
             </div>
           </label>
         </div>
@@ -128,50 +100,45 @@ export function SettingsPanel() {
       <section className="settings-section">
         <h3>Phonetic matching</h3>
         <div className="settings-options">
-          {[
-            { value: 'off',       label: 'Off',       desc: 'Spelling and fuzzy-spelling match only.' },
-            { value: 'soundex',   label: 'Soundex',   desc: 'Catches vowel variations (hot / hut) and same-consonant homophones (two / too).' },
-            { value: 'metaphone', label: 'Metaphone', desc: 'Better for silent-letter homophones (write / right, know / no). May miss some vowel homophones.' },
-            { value: 'both',      label: 'Both',      desc: 'Union of Soundex and Metaphone. Highest coverage, slightly higher false-positive rate.' },
-          ].map(({ value, label, desc }) => (
-            <label key={value} className={`settings-option ${settings.phoneticAlgorithm === value ? 'active' : ''}`}>
-              <input
-                type="radio"
-                name="phoneticAlgorithm"
-                value={value}
-                checked={settings.phoneticAlgorithm === value}
-                onChange={() => set('phoneticAlgorithm', value)}
-              />
-              <div>
-                <strong>{label}</strong>
-                <span>{desc}</span>
-              </div>
-            </label>
-          ))}
+          <label className={`settings-option ${settings.phoneticSoundex ? 'active' : ''}`}>
+            <input
+              type="checkbox"
+              checked={settings.phoneticSoundex}
+              onChange={() => toggle('phoneticSoundex')}
+            />
+            <div>
+              <strong>Soundex</strong>
+              <span>Catches vowel variations (hot / hut) and same-consonant homophones (two / too).</span>
+            </div>
+          </label>
+          <label className={`settings-option ${settings.phoneticMetaphone ? 'active' : ''}`}>
+            <input
+              type="checkbox"
+              checked={settings.phoneticMetaphone}
+              onChange={() => toggle('phoneticMetaphone')}
+            />
+            <div>
+              <strong>Metaphone</strong>
+              <span>Better for silent-letter homophones (write / right, know / no). May miss some vowel homophones.</span>
+            </div>
+          </label>
         </div>
       </section>
 
       <section className="settings-section">
         <h3>Show microphone transcript</h3>
         <div className="settings-options">
-          {[
-            { value: 'off',       label: 'Off',              desc: 'Never shown. Clean and distraction-free.' },
-            { value: 'on-result', label: 'Show after answer', desc: 'Displays what the microphone heard once the result is shown. Useful for understanding why an answer was accepted or rejected.' },
-          ].map(({ value, label, desc }) => (
-            <label key={value} className={`settings-option ${settings.showTranscript === value ? 'active' : ''}`}>
-              <input
-                type="radio"
-                name="showTranscript"
-                value={value}
-                checked={settings.showTranscript === value}
-                onChange={() => set('showTranscript', value)}
-              />
-              <div>
-                <strong>{label}</strong>
-                <span>{desc}</span>
-              </div>
-            </label>
-          ))}
+          <label className={`settings-option ${settings.showTranscript ? 'active' : ''}`}>
+            <input
+              type="checkbox"
+              checked={settings.showTranscript}
+              onChange={() => toggle('showTranscript')}
+            />
+            <div>
+              <strong>Show after answer</strong>
+              <span>Displays what the microphone heard once the result is shown. Useful for understanding why an answer was accepted or rejected.</span>
+            </div>
+          </label>
         </div>
       </section>
     </div>

--- a/src/store/settingsStore.js
+++ b/src/store/settingsStore.js
@@ -1,26 +1,14 @@
 import { createStore, localStorageAdapter } from './index'
 
 const DEFAULT_SETTINGS = {
-  listeningMode: 'hold',    // 'hold' | 'auto'
-  feedbackMode: 'both',     // 'text' | 'voice' | 'both'
-  autoStartDelay: 500,      // ms to wait before auto-starting recognition
-  maxListenDuration: 10000, // ms max listen time (0 = browser default)
-
-  /**
-   * Which phonetic algorithm to use when comparing STT output to expected answers.
-   * 'off'       — spelling/fuzzy only, no phonetic encoding
-   * 'soundex'   — catches vowel variations (hot/hut) and same-consonant homophones (two/too)
-   * 'metaphone' — better for silent-letter homophones (write/right, know/no, phone/fone)
-   * 'both'      — union of Soundex and Metaphone; most permissive
-   */
-  phoneticAlgorithm: 'soundex',
-
-  /**
-   * Whether to show what the microphone/STT actually heard.
-   * 'off'       — never shown (clean default)
-   * 'on-result' — shown after the answer is evaluated (useful for debugging misses)
-   */
-  showTranscript: 'off',
+  autoListen: false,         // true = auto-start listening each card; false = hold-to-speak
+  autoStartDelay: 500,       // ms to wait before auto-starting recognition
+  maxListenDuration: 10000,  // ms max listen time (0 = browser default)
+  feedbackText: true,        // show the answer on screen
+  feedbackVoice: true,       // speak the answer aloud
+  phoneticSoundex: true,     // enable Soundex phonetic matching
+  phoneticMetaphone: false,  // enable Metaphone phonetic matching
+  showTranscript: false,     // show what the microphone heard after result
 }
 
 export const settingsStore = createStore(


### PR DESCRIPTION
All string-enum settings are replaced with independent booleans:
- listeningMode ('hold'|'auto') → autoListen (boolean)
- feedbackMode ('text'|'voice'|'both') → feedbackText + feedbackVoice (booleans)
- phoneticAlgorithm ('off'|'soundex'|'metaphone'|'both') → phoneticSoundex + phoneticMetaphone (booleans)
- showTranscript ('off'|'on-result') → showTranscript (boolean)

SettingsPanel renders checkboxes; runtime logic in FlashcardMode1/4
derives the necessary values from the new boolean flags.

https://claude.ai/code/session_01PYtmRwthxXKqiSqkJcg4Kk