### PR TITLE
Play incorrect sound when user taps the don't-know (?) button

### DIFF
--- a/src/components/FlashcardMode1.tsx
+++ b/src/components/FlashcardMode1.tsx
@@ -140,7 +140,7 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }: Props) {
             disabled={isSpeaking}
             listenMode={settings.autoListen ? 'auto' : 'hold'}
           />
-          <button className="dont-know-btn" onClick={() => setResult('incorrect')} aria-label="Don't know">
+          <button className="dont-know-btn" onClick={() => { if (settings.feedbackSound) playIncorrect(); setResult('incorrect') }} aria-label="Don't know">
             ?
           </button>
         </div>

--- a/src/components/FlashcardMode4.tsx
+++ b/src/components/FlashcardMode4.tsx
@@ -143,7 +143,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
             disabled={isSpeaking}
             listenMode={settings.autoListen ? 'auto' : 'hold'}
           />
-          <button className="dont-know-btn" onClick={() => setResult('incorrect')} aria-label="Don't know">
+          <button className="dont-know-btn" onClick={() => { if (settings.feedbackSound) playIncorrect(); setResult('incorrect') }} aria-label="Don't know">
             ?
           </button>
         </div>


### PR DESCRIPTION
The ? button set result directly without going through handleResult, so feedbackSound was never triggered. Now it calls playIncorrect() first (when feedbackSound is enabled) before setting the result.

https://claude.ai/code/session_01T1BedERGocnKxCVgbH7TBR