### PR TITLE
Unify result handling into a single applyResult path

### DIFF
--- a/src/components/FlashcardMode1.tsx
+++ b/src/components/FlashcardMode1.tsx
@@ -52,12 +52,10 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }: Props) {
     return () => clearTimeout(timer)
   }, [settings.autoListen, settings.autoStartDelay, settings.englishExerciseMode])  // oxlint-disable-line react-hooks/exhaustive-deps
 
-  const handleResult = useCallback(
-    (transcripts: string[]) => {
-      const correct = compareJapanese(card.kana, transcripts, tokenizer ?? null)
-      const r = correct ? 'correct' : 'incorrect'
-      setResult(r)
-      setHeard(transcripts[0] ?? '')
+  const applyResult = useCallback(
+    (correct: boolean, transcript: string) => {
+      setResult(correct ? 'correct' : 'incorrect')
+      setHeard(transcript)
       if (settings.feedbackSound) {
         if (correct) playCorrect(); else playIncorrect()
       }
@@ -65,12 +63,15 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }: Props) {
         speak(card.japanese, 'ja-JP')
       }
     },
-    [card, tokenizer, settings.feedbackSound, settings.feedbackVoice, speak, playCorrect, playIncorrect]
+    [card, settings.feedbackSound, settings.feedbackVoice, speak, playCorrect, playIncorrect]
   )
 
   const { isListening, start, stop } = useSpeechRecognition({
     lang: 'ja-JP',
-    onResult: handleResult,
+    onResult: (transcripts) => applyResult(
+      compareJapanese(card.kana, transcripts, tokenizer ?? null),
+      transcripts[0] ?? ''
+    ),
     onError: setErrorMsg,
   })
 
@@ -140,7 +141,7 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }: Props) {
             disabled={isSpeaking}
             listenMode={settings.autoListen ? 'auto' : 'hold'}
           />
-          <button className="dont-know-btn" onClick={() => { if (settings.feedbackSound) playIncorrect(); setResult('incorrect') }} aria-label="Don't know">
+          <button className="dont-know-btn" onClick={() => applyResult(false, '')} aria-label="Don't know">
             ?
           </button>
         </div>

--- a/src/components/FlashcardMode4.tsx
+++ b/src/components/FlashcardMode4.tsx
@@ -49,17 +49,10 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
   // oxlint-disable-next-line react-hooks/exhaustive-deps -- intentionally fires only on card change
   }, [card, speak])
 
-  const handleResult = useCallback(
-    (transcripts: string[]) => {
-      const phoneticAlgorithm: 'off' | 'soundex' | 'metaphone' | 'both' =
-        settings.phoneticSoundex && settings.phoneticMetaphone ? 'both'
-        : settings.phoneticSoundex ? 'soundex'
-        : settings.phoneticMetaphone ? 'metaphone'
-        : 'off'
-      const correct = compareEnglish(card.english, transcripts, { phoneticAlgorithm })
-      const r = correct ? 'correct' : 'incorrect'
-      setResult(r)
-      setHeard(transcripts[0] ?? '')
+  const applyResult = useCallback(
+    (correct: boolean, transcript: string) => {
+      setResult(correct ? 'correct' : 'incorrect')
+      setHeard(transcript)
       if (settings.feedbackSound) {
         if (correct) playCorrect(); else playIncorrect()
       }
@@ -68,12 +61,22 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
         speak(primaryEnglish, 'en-US')
       }
     },
-    [card, settings.phoneticSoundex, settings.phoneticMetaphone, settings.feedbackSound, settings.feedbackVoice, speak, playCorrect, playIncorrect]
+    [card, settings.feedbackSound, settings.feedbackVoice, speak, playCorrect, playIncorrect]
   )
 
   const { isListening, start, stop } = useSpeechRecognition({
     lang: 'en-US',
-    onResult: handleResult,
+    onResult: (transcripts) => {
+      const phoneticAlgorithm: 'off' | 'soundex' | 'metaphone' | 'both' =
+        settings.phoneticSoundex && settings.phoneticMetaphone ? 'both'
+        : settings.phoneticSoundex ? 'soundex'
+        : settings.phoneticMetaphone ? 'metaphone'
+        : 'off'
+      applyResult(
+        compareEnglish(card.english, transcripts, { phoneticAlgorithm }),
+        transcripts[0] ?? ''
+      )
+    },
     onError: setErrorMsg,
   })
 
@@ -143,7 +146,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
             disabled={isSpeaking}
             listenMode={settings.autoListen ? 'auto' : 'hold'}
           />
-          <button className="dont-know-btn" onClick={() => { if (settings.feedbackSound) playIncorrect(); setResult('incorrect') }} aria-label="Don't know">
+          <button className="dont-know-btn" onClick={() => applyResult(false, '')} aria-label="Don't know">
             ?
           </button>
         </div>


### PR DESCRIPTION
Both the STT callback and the don't-know button now go through the same applyResult(correct, transcript) function, so sound and voice feedback are always applied identically regardless of how the answer was submitted.

https://claude.ai/code/session_01T1BedERGocnKxCVgbH7TBR