### PR TITLE
Accept multiple Japanese answers for the same English translation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -280,6 +280,7 @@ function StudyApp({ words, isVocabLoading, isVocabError, manifest, activeLang, a
                   <FlashcardMode1
                     key={`m1-${cardKey}`}
                     card={card}
+                    words={words}
                     tokenizer={tokenizer}
                     cardType={cardType}
                     onAnswer={handleAnswer}

--- a/src/components/FlashcardMode1.tsx
+++ b/src/components/FlashcardMode1.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { RecordButton } from './RecordButton'
 import { CardTypeBadge } from './CardTypeBadge'
 import { FlashcardFeedback } from './FlashcardFeedback'
@@ -12,12 +12,13 @@ import type { KuromojiTokenizer } from '../types/kuromoji'
 
 interface Props {
   card: Word
+  words: Word[]
   tokenizer: KuromojiTokenizer | undefined
   cardType: 'due' | 'new' | 'extra'
   onAnswer: (quality: number, heard: string) => void
 }
 
-export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }: Props) {
+export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: Props) {
   const [result, setResult] = useState<'correct' | 'incorrect' | null>(null)
   const [heard, setHeard] = useState('')
   const [errorMsg, setErrorMsg] = useState('')
@@ -25,6 +26,19 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }: Props) {
   const [correctionHeard, setCorrectionHeard] = useState('')
   const [correctionResult, setCorrectionResult] = useState<'correct' | 'incorrect' | null>(null)
   const settings = useSettingsStore()
+
+  // Build list of all kana that share an English translation with this card,
+  // so e.g. both あお and あおい are accepted for "blue"
+  const acceptedKana = useMemo(() => {
+    const englishSet = new Set(card.english.map((e) => e.toLowerCase()))
+    const kanaSet = new Set<string>([card.kana])
+    for (const w of words) {
+      if (w.english.some((e) => englishSet.has(e.toLowerCase()))) {
+        kanaSet.add(w.kana)
+      }
+    }
+    return [...kanaSet]
+  }, [card, words])
   const { isSpeaking, speak } = useSpeechSynthesis()
   const { playCorrect, playIncorrect } = useAudioFeedback()
   const autoStarted = useRef(false)
@@ -72,7 +86,7 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }: Props) {
   const { isListening, start, stop } = useSpeechRecognition({
     lang: 'ja-JP',
     onResult: (transcripts) => applyResult(
-      compareJapanese(card.kana, transcripts, tokenizer ?? null),
+      compareJapanese(acceptedKana, transcripts, tokenizer ?? null),
       transcripts[0] ?? ''
     ),
     onError: setErrorMsg,
@@ -89,7 +103,7 @@ export function FlashcardMode1({ card, tokenizer, cardType, onAnswer }: Props) {
   const correction = useSpeechRecognition({
     lang: 'ja-JP',
     onResult: (transcripts) => {
-      const correct = compareJapanese(card.kana, transcripts, tokenizer ?? null)
+      const correct = compareJapanese(acceptedKana, transcripts, tokenizer ?? null)
       setCorrectionHeard(transcripts[0] ?? '')
       setCorrectionResult(correct ? 'correct' : 'incorrect')
       if (correct) {

--- a/src/utils/normalize.test.ts
+++ b/src/utils/normalize.test.ts
@@ -21,30 +21,40 @@ describe('toHiragana', () => {
 
 describe('compareJapanese', () => {
   it('matches exact hiragana', () => {
-    expect(compareJapanese('あつい', ['あつい'], noTokenizer)).toBe(true)
+    expect(compareJapanese(['あつい'], ['あつい'], noTokenizer)).toBe(true)
   })
 
   it('matches katakana candidate for hiragana expected', () => {
-    expect(compareJapanese('あつい', ['アツイ'], noTokenizer)).toBe(true)
+    expect(compareJapanese(['あつい'], ['アツイ'], noTokenizer)).toBe(true)
   })
 
   it('accepts levenshtein-1 difference', () => {
     // one character off
-    expect(compareJapanese('あつい', ['あつい'], noTokenizer)).toBe(true)
-    expect(compareJapanese('あつい', ['あついい'], noTokenizer)).toBe(true)
+    expect(compareJapanese(['あつい'], ['あつい'], noTokenizer)).toBe(true)
+    expect(compareJapanese(['あつい'], ['あついい'], noTokenizer)).toBe(true)
   })
 
   it('accepts expected as substring of candidate (politeness forms)', () => {
     // "あつい" is contained in "あついです"
-    expect(compareJapanese('あつい', ['あついです'], noTokenizer)).toBe(true)
+    expect(compareJapanese(['あつい'], ['あついです'], noTokenizer)).toBe(true)
   })
 
   it('rejects clearly wrong answer', () => {
-    expect(compareJapanese('あつい', ['まずい'], noTokenizer)).toBe(false)
+    expect(compareJapanese(['あつい'], ['まずい'], noTokenizer)).toBe(false)
   })
 
   it('returns false for empty candidates', () => {
-    expect(compareJapanese('あつい', [], noTokenizer)).toBe(false)
+    expect(compareJapanese(['あつい'], [], noTokenizer)).toBe(false)
+  })
+
+  it('accepts any of multiple expected answers', () => {
+    // e.g. あお (noun) and あおい (i-adj) both valid for "blue"
+    expect(compareJapanese(['あお', 'あおい'], ['あお'], noTokenizer)).toBe(true)
+    expect(compareJapanese(['あお', 'あおい'], ['あおい'], noTokenizer)).toBe(true)
+  })
+
+  it('rejects wrong answer even with multiple expected', () => {
+    expect(compareJapanese(['あお', 'あおい'], ['まずい'], noTokenizer)).toBe(false)
   })
 })
 

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -49,25 +49,29 @@ function levenshtein(a: string, b: string): number {
 /**
  * Compare Japanese: normalize both strings to hiragana and check fuzzy match.
  * Also handles transcripts with extra surrounding words (e.g. "あついです" for "あつい").
+ * Accepts multiple expected answers so that words sharing the same English
+ * translation (e.g. あお / あおい for "blue") are all considered correct.
  */
-export function compareJapanese(expected: string, candidates: string[], tokenizer: KuromojiTokenizer | null): boolean {
-  const normalizedExpected = toHiragana(expected, tokenizer)
-  for (const candidate of candidates) {
-    const normalizedCandidate = toHiragana(candidate, tokenizer)
+export function compareJapanese(expectedList: string[], candidates: string[], tokenizer: KuromojiTokenizer | null): boolean {
+  for (const expected of expectedList) {
+    const normalizedExpected = toHiragana(expected, tokenizer)
+    for (const candidate of candidates) {
+      const normalizedCandidate = toHiragana(candidate, tokenizer)
 
-    // Full-phrase exact or near match
-    if (normalizedExpected === normalizedCandidate) return true
-    if (levenshtein(normalizedExpected, normalizedCandidate) <= 1) return true
+      // Full-phrase exact or near match
+      if (normalizedExpected === normalizedCandidate) return true
+      if (levenshtein(normalizedExpected, normalizedCandidate) <= 1) return true
 
-    // Word-level: STT may output multiple space-separated segments
-    for (const word of normalizedCandidate.split(/\s+/).filter(Boolean)) {
-      if (word === normalizedExpected) return true
-      if (levenshtein(word, normalizedExpected) <= 1) return true
+      // Word-level: STT may output multiple space-separated segments
+      for (const word of normalizedCandidate.split(/\s+/).filter(Boolean)) {
+        if (word === normalizedExpected) return true
+        if (levenshtein(word, normalizedExpected) <= 1) return true
+      }
+
+      // Substring: expected hiragana contained within a longer transcript
+      // (e.g. politeness forms: "あついです" contains "あつい")
+      if (normalizedCandidate.includes(normalizedExpected)) return true
     }
-
-    // Substring: expected hiragana contained within a longer transcript
-    // (e.g. politeness forms: "あついです" contains "あつい")
-    if (normalizedCandidate.includes(normalizedExpected)) return true
   }
   return false
 }


### PR DESCRIPTION
When quizzing English→Japanese, words sharing the same English translation
(e.g. あお/あおい for "blue") are now all accepted as correct answers.

- Refactor compareJapanese to accept expectedList: string[] (mirroring compareEnglish)
- Build reverse lookup in FlashcardMode1 to find all kana sharing an English term
- No data structure changes needed — relationships derived at runtime

https://claude.ai/code/session_017PrsZTzKTWDyaem1rWS4Qx