### PR TITLE
feat: add streaks, GitHub link, and pause mic during playback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,7 +115,8 @@ function StudyApp({ words, isVocabLoading, isVocabError, manifest, activeLang, a
   const [previousResult, setPreviousResult] = useState<PreviousResultData | null>(null)
 
   const cardStates = useAppStore((s) => s.cards)
-  const { applyCardReview, reset } = useAppStore()
+  const streakCount = useAppStore((s) => s.streakCount)
+  const { applyCardReview, reset, recordStudyDay } = useAppStore()
   const settings = useSettingsStore()
   const { tokenizer, isLoading: kuromojiLoading, isError: kuromojiError } = useKuromoji()
 
@@ -132,6 +133,7 @@ function StudyApp({ words, isVocabLoading, isVocabError, manifest, activeLang, a
       const existing = cardStates[card.kana]
       const updated = applyReview(existing, quality)
       applyCardReview(card.kana, updated)
+      recordStudyDay()
       setPreviousResult({
         japanese: card.japanese,
         kana: card.kana,
@@ -144,7 +146,7 @@ function StudyApp({ words, isVocabLoading, isVocabError, manifest, activeLang, a
       setReviewedCount((n) => n + 1)
       setCardKey((k) => k + 1)
     },
-    [card, cardStates, applyCardReview, mode]
+    [card, cardStates, applyCardReview, recordStudyDay, mode]
   )
 
   const handlePreviousOverride = useCallback(
@@ -266,6 +268,7 @@ function StudyApp({ words, isVocabLoading, isVocabError, manifest, activeLang, a
                   reviewedCount={reviewedCount}
                   nextDueDate={nextDueDate}
                   cardType={cardType}
+                  streakCount={streakCount}
                 />
 
                 {previousResult && settings.manualGrading && (
@@ -302,6 +305,11 @@ function StudyApp({ words, isVocabLoading, isVocabError, manifest, activeLang, a
 
       <footer className="app-footer">
         <p>Requires Chrome or Edge · Progress saved automatically</p>
+        <p>
+          <a href="https://github.com/meesvandongen/japanese-learning" target="_blank" rel="noopener noreferrer" className="github-link">
+            GitHub
+          </a>
+        </p>
       </footer>
     </div>
   )

--- a/src/components/FlashcardMode1.tsx
+++ b/src/components/FlashcardMode1.tsx
@@ -92,6 +92,11 @@ export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: P
     onError: setErrorMsg,
   })
 
+  // Pause microphone when audio is playing to prevent recording playback
+  useEffect(() => {
+    if (isSpeaking && isListening) stop()
+  }, [isSpeaking, isListening, stop])
+
   // Enforce max listen duration in auto mode
   useEffect(() => {
     if (!isListening || !settings.maxListenDuration) return
@@ -115,6 +120,11 @@ export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: P
     },
     onError: setErrorMsg,
   })
+
+  // Pause correction microphone when audio is playing
+  useEffect(() => {
+    if (isSpeaking && correction.isListening) correction.stop()
+  }, [isSpeaking, correction.isListening, correction.stop]) // oxlint-disable-line react-hooks/exhaustive-deps
 
   // Enter correction phase on incorrect result when speakToCorrect is on
   useEffect(() => {

--- a/src/components/FlashcardMode4.tsx
+++ b/src/components/FlashcardMode4.tsx
@@ -83,6 +83,11 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
     onError: setErrorMsg,
   })
 
+  // Pause microphone when audio is playing to prevent recording playback
+  useEffect(() => {
+    if (isSpeaking && isListening) stop()
+  }, [isSpeaking, isListening, stop])
+
   // Enforce max listen duration in auto mode
   useEffect(() => {
     if (!isListening || !settings.maxListenDuration) return
@@ -114,6 +119,11 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
     },
     onError: setErrorMsg,
   })
+
+  // Pause correction microphone when audio is playing
+  useEffect(() => {
+    if (isSpeaking && correction.isListening) correction.stop()
+  }, [isSpeaking, correction.isListening, correction.stop]) // oxlint-disable-line react-hooks/exhaustive-deps
 
   // Enter correction phase on incorrect result when speakToCorrect is on
   useEffect(() => {

--- a/src/components/SessionStats.tsx
+++ b/src/components/SessionStats.tsx
@@ -6,6 +6,7 @@ interface Props {
   reviewedCount: number
   nextDueDate: number | null
   cardType: 'due' | 'new' | 'extra'
+  streakCount: number
 }
 
 interface PillProps {
@@ -18,7 +19,7 @@ interface PillProps {
 /**
  * Session stats bar shown above the flashcard.
  */
-export function SessionStats({ dueCount, newCount, reviewedCount, nextDueDate, cardType }: Props) {
+export function SessionStats({ dueCount, newCount, reviewedCount, nextDueDate, cardType, streakCount }: Props) {
   const allCaughtUp = dueCount === 0 && newCount === 0
 
   return (
@@ -26,6 +27,7 @@ export function SessionStats({ dueCount, newCount, reviewedCount, nextDueDate, c
       <Pill slot="due" label="Due" value={dueCount} accent={dueCount > 0 ? 'due' : 'zero'} />
       <Pill slot="new" label="New" value={newCount} accent={newCount > 0 ? 'new' : 'zero'} />
       <Pill slot="session" label="Session" value={reviewedCount} accent="session" />
+      {streakCount > 0 && <Pill slot="streak" label="Streak" value={streakCount} accent="streak" />}
 
       {allCaughtUp && cardType === 'extra' && (
         <span className="caught-up-badge">

--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useAppStore } from '../store/appStore'
 import { LanguageSelector } from './LanguageSelector'
 import { LevelSelector } from './LevelSelector'
@@ -25,6 +25,9 @@ export function SettingsPage({ manifest, activeLang, activeLevel, onClose }: Pro
   const [view, setView] = useState<'overview' | 'language' | 'level'>('overview')
   // pendingLangId tracks a language pick that hasn't been paired with a level yet
   const [pendingLangId, setPendingLangId] = useState<string | null>(null)
+  const streakCount = useAppStore((s) => s.streakCount)
+  const importStreak = useAppStore((s) => s.importStreak)
+  const streakInputRef = useRef<HTMLInputElement>(null)
 
   function handleLanguagePick(langId: string) {
     setPendingLangId(langId)
@@ -107,6 +110,44 @@ export function SettingsPage({ manifest, activeLang, activeLevel, onClose }: Pro
           >
             Change
           </button>
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <h3 className="settings-section-title">Streak</h3>
+        <div className="settings-row">
+          <div className="settings-info">
+            <span className="settings-label">Current streak</span>
+            <span className="settings-display-value">{streakCount} {streakCount === 1 ? 'day' : 'days'}</span>
+          </div>
+        </div>
+        <div className="settings-row">
+          <div className="settings-info">
+            <span className="settings-label">Import streak</span>
+            <span className="settings-hint">Set your streak to a custom value</span>
+          </div>
+          <div className="streak-import-row">
+            <input
+              ref={streakInputRef}
+              type="number"
+              min="0"
+              className="streak-input"
+              placeholder="0"
+              aria-label="Streak value"
+            />
+            <button
+              className="settings-change-btn"
+              onClick={() => {
+                const val = Number(streakInputRef.current?.value)
+                if (Number.isFinite(val) && val >= 0) {
+                  importStreak(val)
+                  if (streakInputRef.current) streakInputRef.current.value = ''
+                }
+              }}
+            >
+              Set
+            </button>
+          </div>
         </div>
       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -575,6 +575,7 @@ body {
 .pill-due    { background: #ffe5e5; color: #7f1d1d; }
 .pill-new    { background: #dbeafe; color: #1e3a5f; }
 .pill-session { background: #f0fdf4; color: #14532d; }
+.pill-streak { background: #fef3c7; color: #78350f; }
 .pill-zero   { background: var(--border); color: var(--muted); }
 
 .caught-up-badge {
@@ -933,6 +934,17 @@ body {
   border-top: 1px solid var(--border);
 }
 
+.github-link {
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.github-link:hover {
+  color: var(--primary);
+  text-decoration: underline;
+}
+
 /* Transcript (what the microphone heard) */
 .transcript-heard {
   margin-top: 10px;
@@ -1090,5 +1102,27 @@ body {
 .correction-skip-btn:hover {
   background: var(--muted);
   color: white;
+}
+
+/* Streak import */
+.streak-import-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.streak-input {
+  width: 72px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1.5px solid var(--border);
+  font-size: 0.9rem;
+  text-align: center;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.streak-input:focus {
+  border-color: var(--primary);
 }
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2,13 +2,27 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { CardState } from '../types'
 
+/** Returns the date string (YYYY-MM-DD) for a given timestamp in local time. */
+function toDateString(ts: number): string {
+  const d = new Date(ts)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
 interface AppState {
   cards: Record<string, CardState>
   selectedLanguageId: string | null
   selectedLevelId: string | null
+  /** Current streak length in days */
+  streakCount: number
+  /** ISO date string (YYYY-MM-DD) of the last day the user studied */
+  streakLastDate: string | null
   setLanguage: (id: string) => void
   setLevel: (id: string) => void
   applyCardReview: (kana: string, updated: CardState) => void
+  /** Record that the user studied today — updates the streak accordingly. */
+  recordStudyDay: () => void
+  /** Import a streak value (and set lastDate to today so it continues). */
+  importStreak: (count: number) => void
   reset: () => void
 }
 
@@ -16,6 +30,8 @@ const initialState = {
   cards: {} as Record<string, CardState>,
   selectedLanguageId: null as string | null,
   selectedLevelId: null as string | null,
+  streakCount: 0,
+  streakLastDate: null as string | null,
 }
 
 export const useAppStore = create<AppState>()(
@@ -26,6 +42,17 @@ export const useAppStore = create<AppState>()(
       setLevel: (id) => set({ selectedLevelId: id }),
       applyCardReview: (kana, updated) =>
         set((s) => ({ cards: { ...s.cards, [kana]: updated } })),
+      recordStudyDay: () =>
+        set((s) => {
+          const today = toDateString(Date.now())
+          if (s.streakLastDate === today) return s // already recorded today
+
+          const yesterday = toDateString(Date.now() - 86_400_000)
+          const newCount = s.streakLastDate === yesterday ? s.streakCount + 1 : 1
+          return { streakCount: newCount, streakLastDate: today }
+        }),
+      importStreak: (count) =>
+        set({ streakCount: Math.max(0, Math.round(count)), streakLastDate: toDateString(Date.now()) }),
       reset: () => set(initialState),
     }),
     { name: 'jp-flashcards-srs-v1' }


### PR DESCRIPTION
- Issue #12: Add daily streak tracking with persistence in appStore.
  Streaks increment when studying on consecutive days, reset on gaps.
  Display streak count in SessionStats pill. Add streak import in Settings.
- Issue #17: Add GitHub repository link in the app footer.
- Issue #25: Stop speech recognition whenever speech synthesis is active,
  preventing the microphone from recording audio playback.

Closes #12, closes #17, closes #25

https://claude.ai/code/session_019RNina7rRRpdrmvrnLSsaS