### PR TITLE
Add PWA support for standalone homescreen mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Japanese Flashcards</title>
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="theme-color" content="#e53935" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Flashcards" />
+    <link rel="apple-touch-icon" href="/icon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="80" fill="#e53935"/>
+  <text x="256" y="360" font-family="serif" font-size="300" text-anchor="middle" fill="white">日</text>
+</svg>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Japanese Flashcards",
+  "short_name": "Flashcards",
+  "description": "Japanese language learning flashcards",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#e53935",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,3 @@
+// Minimal service worker required for PWA installability
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (e) => e.waitUntil(self.clients.claim()));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
 import './index.css'
 
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js')
+}
+
 const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
Adds a web app manifest with display: standalone so the app launches
without browser chrome when added to the homescreen. Includes a minimal
service worker (required for installability on Android/Chrome) and
Apple-specific meta tags for iOS Safari.

https://claude.ai/code/session_011Gsaq2cce7nf1kRe3ytmXt