### PR TITLE
feat: add kanji to vocabulary with kana readings, add play-again button to Mode 1

### DIFF
--- a/src/components/FlashcardFeedback.tsx
+++ b/src/components/FlashcardFeedback.tsx
@@ -5,6 +5,9 @@ interface Props {
   showTranscript: boolean
   correctText: string
   incorrectText: string
+  kanaReading?: string
+  onPlayAgain?: () => void
+  isPlaying?: boolean
   manualGrading?: boolean
   onOverrideCorrect?: () => void
   onOverrideIncorrect?: () => void
@@ -17,22 +20,34 @@ export function FlashcardFeedback({
   showTranscript,
   correctText,
   incorrectText,
+  kanaReading,
+  onPlayAgain,
+  isPlaying,
   manualGrading,
   onOverrideCorrect,
   onOverrideIncorrect,
 }: Props) {
   if (!result) return null
 
+  const answerText = result === 'correct' ? correctText : incorrectText
+
   return (
     <>
-      {result === 'correct' && showText && (
-        <div className="feedback correct">
-          ✓ <span className="answer-shown">{correctText}</span>
-        </div>
-      )}
-      {result === 'incorrect' && showText && (
-        <div className="feedback incorrect">
-          <span className="answer-shown">{incorrectText}</span>
+      {showText && (
+        <div className={`feedback ${result}`}>
+          {result === 'correct' && '✓ '}
+          <span className="answer-shown">{answerText}</span>
+          {kanaReading && kanaReading !== answerText && (
+            <span className="answer-kana">{kanaReading}</span>
+          )}
+          {onPlayAgain && (
+            <button
+              className={`play-btn feedback-play ${isPlaying ? 'playing' : ''}`}
+              onClick={onPlayAgain}
+            >
+              {isPlaying ? '🔊 Playing…' : '🔊 Play again'}
+            </button>
+          )}
         </div>
       )}
       {!showText && (

--- a/src/components/FlashcardMode1.tsx
+++ b/src/components/FlashcardMode1.tsx
@@ -217,6 +217,9 @@ export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: P
         showTranscript={settings.showTranscript}
         correctText={card.japanese}
         incorrectText={card.japanese}
+        kanaReading={card.kana}
+        onPlayAgain={() => speak(card.japanese, 'ja-JP')}
+        isPlaying={isSpeaking}
         manualGrading={settings.manualGrading}
         onOverrideCorrect={() => overrideGrade(4)}
         onOverrideIncorrect={() => overrideGrade(1)}

--- a/src/components/FlashcardMode4.tsx
+++ b/src/components/FlashcardMode4.tsx
@@ -194,7 +194,12 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
       )}
 
       {showJapaneseText && (
-        <div className="card-prompt japanese-prompt">{card.japanese}</div>
+        <div className="card-prompt japanese-prompt">
+          {card.japanese}
+          {card.japanese !== card.kana && (
+            <span className="card-kana-reading">{card.kana}</span>
+          )}
+        </div>
       )}
 
       <div className="card-hint">Speak the English translation</div>

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -122,7 +122,12 @@ function WordRow({ word }: { word: EnrichedWord }) {
 
   return (
     <div className={`word-row status-${status}`}>
-      <div className="word-kana">{word.japanese}</div>
+      <div className="word-kana">
+        {word.japanese}
+        {word.japanese !== word.kana && (
+          <span className="word-reading">{word.kana}</span>
+        )}
+      </div>
       <div className="word-english">{primary}</div>
       <div className="word-meta">
         <span className={`status-badge badge-${status}`}>{STATUS_LABEL[status]}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -344,6 +344,20 @@ body {
   margin-top: 6px;
 }
 
+.answer-kana {
+  display: block;
+  font-size: 1rem;
+  font-weight: 400;
+  opacity: 0.75;
+  margin-top: 2px;
+}
+
+.feedback-play {
+  margin-top: 10px;
+  padding: 8px 18px;
+  font-size: 0.9rem;
+}
+
 /* Next button */
 .next-btn {
   padding: 12px 28px;
@@ -550,6 +564,12 @@ body {
   font-size: 1.1rem;
   font-weight: 600;
   min-width: 80px;
+}
+.word-reading {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 400;
+  opacity: 0.7;
 }
 .word-english {
   flex: 1;
@@ -1101,6 +1121,14 @@ body {
   font-weight: 700;
   text-align: center;
   margin: 8px 0;
+}
+
+.card-kana-reading {
+  display: block;
+  font-size: 1rem;
+  font-weight: 400;
+  opacity: 0.65;
+  margin-top: 2px;
 }
 
 /* Correction phase — speak the correct answer after getting it wrong */


### PR DESCRIPTION
- Update vocabulary to use proper kanji forms (食べる, 飲む, 行く, etc.)
  while keeping kana field for answer comparison
- Show kana reading below kanji in Mode 1 feedback when they differ
- Add "Play again" button to Mode 1 feedback that plays the Japanese
  answer pronunciation (not the English question)
- Show Japanese word with kana reading in Mode 4 feedback for reinforcement
- Show kana reading alongside kanji in Profile page word list

https://claude.ai/code/session_01PP5uFNEBwREdfZK6Y1bMgb