### PR TITLE
Fix badge text color invisible when tab is selected

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -532,7 +532,15 @@ body {
   font-weight: 700;
 }
 .profile-tab.active .tab-count {
-  background: currentColor;
+  background: var(--primary);
+  color: white;
+}
+.profile-tab.tab-overdue.active .tab-count {
+  background: var(--danger);
+  color: white;
+}
+.profile-tab.tab-mastered.active .tab-count {
+  background: #7c3aed;
   color: white;
 }
 


### PR DESCRIPTION
`background: currentColor` in the same rule as `color: white` resolves
currentColor to white, making both background and text white. Replace with
explicit colors matching each active tab variant (primary, danger, purple).

https://claude.ai/code/session_012JyPkEgNvzTySJGrCJSPaD