### PR TITLE
Add report mistake button that links to GitHub issue creation

### DIFF
--- a/src/components/FlashcardFeedback.tsx
+++ b/src/components/FlashcardFeedback.tsx
@@ -11,6 +11,7 @@ interface Props {
   manualGrading?: boolean
   onOverrideCorrect?: () => void
   onOverrideIncorrect?: () => void
+  reportUrl?: string
 }
 
 export function FlashcardFeedback({
@@ -26,6 +27,7 @@ export function FlashcardFeedback({
   manualGrading,
   onOverrideCorrect,
   onOverrideIncorrect,
+  reportUrl,
 }: Props) {
   if (!result) return null
 
@@ -71,6 +73,17 @@ export function FlashcardFeedback({
             </button>
           )}
         </div>
+      )}
+      {reportUrl && (
+        <a
+          className="report-mistake-link"
+          href={reportUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+        >
+          Report mistake
+        </a>
       )}
     </>
   )

--- a/src/components/FlashcardMode1.tsx
+++ b/src/components/FlashcardMode1.tsx
@@ -7,6 +7,7 @@ import { useSpeechSynthesis } from '../hooks/useSpeechSynthesis'
 import { useAudioFeedback } from '../hooks/useAudioFeedback'
 import { compareJapanese, toHiragana } from '../utils/normalize'
 import { useSettingsStore } from '../store/settingsStore'
+import { buildReportUrl } from '../utils/reportUrl'
 import type { Word } from '../types'
 import type { KuromojiTokenizer } from '../types/kuromoji'
 
@@ -224,6 +225,7 @@ export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: P
         manualGrading={settings.manualGrading}
         onOverrideCorrect={() => overrideGrade(4)}
         onOverrideIncorrect={() => overrideGrade(1)}
+        reportUrl={buildReportUrl(card)}
       />
 
       {correctionPhase && correctionResult !== 'correct' && (

--- a/src/components/FlashcardMode4.tsx
+++ b/src/components/FlashcardMode4.tsx
@@ -7,6 +7,7 @@ import { useSpeechSynthesis } from '../hooks/useSpeechSynthesis'
 import { useAudioFeedback } from '../hooks/useAudioFeedback'
 import { compareEnglish } from '../utils/normalize'
 import { useSettingsStore } from '../store/settingsStore'
+import { buildReportUrl } from '../utils/reportUrl'
 import type { Word } from '../types'
 
 interface Props {
@@ -214,6 +215,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
         manualGrading={settings.manualGrading}
         onOverrideCorrect={() => overrideGrade(4)}
         onOverrideIncorrect={() => overrideGrade(1)}
+        reportUrl={buildReportUrl(card)}
       />
 
       {correctionPhase && correctionResult !== 'correct' && (

--- a/src/components/PreviousResult.tsx
+++ b/src/components/PreviousResult.tsx
@@ -1,3 +1,6 @@
+import type { Word } from '../types'
+import { buildReportUrl } from '../utils/reportUrl'
+
 export interface PreviousResultData {
   japanese: string
   kana: string
@@ -48,6 +51,16 @@ export function PreviousResult({ data, manualGrading, onOverride }: Props) {
           Mark as incorrect
         </button>
       )}
+      <a
+        className="report-mistake-link report-mistake-compact"
+        href={buildReportUrl({ japanese: data.japanese, kana: data.kana, english: data.english } as Word)}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={(e) => e.stopPropagation()}
+        title="Report mistake"
+      >
+        Report
+      </a>
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1123,6 +1123,28 @@ body {
   padding: 5px 12px;
 }
 
+/* ─── Report mistake link ─────────────────────────────────────────────── */
+
+.report-mistake-link {
+  display: inline-block;
+  margin-top: 10px;
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.report-mistake-link:hover {
+  color: var(--danger);
+  text-decoration: underline;
+}
+
+.report-mistake-compact {
+  margin-top: 0;
+  flex-shrink: 0;
+  font-size: 0.72rem;
+}
+
 /* Japanese prompt text in Mode 4 (text/audio+text modes) */
 .japanese-prompt {
   font-size: 2rem;

--- a/src/utils/reportUrl.ts
+++ b/src/utils/reportUrl.ts
@@ -1,0 +1,22 @@
+import type { Word } from '../types'
+
+const REPO_URL = 'https://github.com/meesvandongen/japanese-learning'
+
+export function buildReportUrl(word: Word): string {
+  const title = `Vocab mistake: ${word.japanese} (${word.kana}) – ${word.english.join(', ')}`
+  const body = [
+    `**Word:** ${word.japanese}`,
+    `**Reading:** ${word.kana}`,
+    `**English:** ${word.english.join(', ')}`,
+    word.hint ? `**Hint:** ${word.hint}` : '',
+    '',
+    '**What is wrong?**',
+    '',
+    '<!-- Please describe the issue below -->',
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  const params = new URLSearchParams({ title, body, labels: 'vocab-mistake' })
+  return `${REPO_URL}/issues/new?${params.toString()}`
+}


### PR DESCRIPTION
Shows a "Report mistake" link after answering a flashcard and in the
previous result banner. The link opens a new GitHub issue prefilled
with the word's japanese text, reading, and english translations.

https://claude.ai/code/session_01VbWG9gUY3DCB7Z1sNR6ezV