### PR TITLE
Track STT transcript and "I don't know" skip in feedback

### DIFF
--- a/src/components/FlashcardMode1.tsx
+++ b/src/components/FlashcardMode1.tsx
@@ -226,7 +226,7 @@ export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: P
         manualGrading={settings.manualGrading}
         onOverrideCorrect={() => overrideGrade(4)}
         onOverrideIncorrect={() => overrideGrade(1)}
-        reportUrl={buildReportUrl(card)}
+        reportUrl={buildReportUrl(card, { heard, skipped })}
       />
 
       {correctionPhase && correctionResult !== 'correct' && (

--- a/src/components/FlashcardMode1.tsx
+++ b/src/components/FlashcardMode1.tsx
@@ -16,12 +16,13 @@ interface Props {
   words: Word[]
   tokenizer: KuromojiTokenizer | undefined
   cardType: 'due' | 'new' | 'extra'
-  onAnswer: (quality: number, heard: string) => void
+  onAnswer: (quality: number, heard: string, skipped: boolean) => void
 }
 
 export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: Props) {
   const [result, setResult] = useState<'correct' | 'incorrect' | null>(null)
   const [heard, setHeard] = useState('')
+  const [skipped, setSkipped] = useState(false)
   const [errorMsg, setErrorMsg] = useState('')
   const [correctionPhase, setCorrectionPhase] = useState(false)
   const [correctionHeard, setCorrectionHeard] = useState('')
@@ -164,24 +165,24 @@ export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: P
     if (!result) return
     if (result === 'incorrect' && settings.speakToCorrect) return
     const delay = result === 'correct' ? 1200 : 2500
-    advanceTimerRef.current = setTimeout(() => onAnswer(result === 'correct' ? 4 : 1, heard), delay)
+    advanceTimerRef.current = setTimeout(() => onAnswer(result === 'correct' ? 4 : 1, heard, skipped), delay)
     return () => {
       if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current)
     }
-  }, [result, heard, onAnswer, settings.speakToCorrect])
+  }, [result, heard, skipped, onAnswer, settings.speakToCorrect])
 
   // Auto-advance after successful correction
   useEffect(() => {
     if (correctionResult !== 'correct') return
-    advanceTimerRef.current = setTimeout(() => onAnswer(1, heard), 1200)
+    advanceTimerRef.current = setTimeout(() => onAnswer(1, heard, skipped), 1200)
     return () => {
       if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current)
     }
-  }, [correctionResult, heard, onAnswer])
+  }, [correctionResult, heard, skipped, onAnswer])
 
   function overrideGrade(quality: number) {
     if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current)
-    onAnswer(quality, heard)
+    onAnswer(quality, heard, skipped)
   }
 
   const primaryEnglish = Array.isArray(card.english) ? card.english[0] : card.english
@@ -246,7 +247,7 @@ export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: P
           )}
           <button
             className="correction-skip-btn"
-            onClick={() => onAnswer(1, heard)}
+            onClick={() => onAnswer(1, heard, skipped)}
           >
             Skip
           </button>
@@ -262,7 +263,7 @@ export function FlashcardMode1({ card, words, tokenizer, cardType, onAnswer }: P
             disabled={isSpeaking}
             listenMode={settings.autoListen ? 'auto' : 'hold'}
           />
-          <button className="dont-know-btn" onClick={() => applyResult(false, '')} aria-label="Don't know">
+          <button className="dont-know-btn" onClick={() => { setSkipped(true); applyResult(false, '') }} aria-label="Don't know">
             ?
           </button>
         </div>

--- a/src/components/FlashcardMode4.tsx
+++ b/src/components/FlashcardMode4.tsx
@@ -13,12 +13,13 @@ import type { Word } from '../types'
 interface Props {
   card: Word
   cardType: 'due' | 'new' | 'extra'
-  onAnswer: (quality: number, heard: string) => void
+  onAnswer: (quality: number, heard: string, skipped: boolean) => void
 }
 
 export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
   const [result, setResult] = useState<'correct' | 'incorrect' | null>(null)
   const [heard, setHeard] = useState('')
+  const [skipped, setSkipped] = useState(false)
   const [errorMsg, setErrorMsg] = useState('')
   const [correctionPhase, setCorrectionPhase] = useState(false)
   const [correctionHeard, setCorrectionHeard] = useState('')
@@ -155,24 +156,24 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
     if (!result) return
     if (result === 'incorrect' && settings.speakToCorrect) return
     const delay = result === 'correct' ? 1200 : 2500
-    advanceTimerRef.current = setTimeout(() => onAnswer(result === 'correct' ? 4 : 1, heard), delay)
+    advanceTimerRef.current = setTimeout(() => onAnswer(result === 'correct' ? 4 : 1, heard, skipped), delay)
     return () => {
       if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current)
     }
-  }, [result, heard, onAnswer, settings.speakToCorrect])
+  }, [result, heard, skipped, onAnswer, settings.speakToCorrect])
 
   // Auto-advance after successful correction
   useEffect(() => {
     if (correctionResult !== 'correct') return
-    advanceTimerRef.current = setTimeout(() => onAnswer(1, heard), 1200)
+    advanceTimerRef.current = setTimeout(() => onAnswer(1, heard, skipped), 1200)
     return () => {
       if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current)
     }
-  }, [correctionResult, heard, onAnswer])
+  }, [correctionResult, heard, skipped, onAnswer])
 
   function overrideGrade(quality: number) {
     if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current)
-    onAnswer(quality, heard)
+    onAnswer(quality, heard, skipped)
   }
 
   const primaryEnglish = Array.isArray(card.english) ? card.english[0] : card.english
@@ -236,7 +237,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
           )}
           <button
             className="correction-skip-btn"
-            onClick={() => onAnswer(1, heard)}
+            onClick={() => onAnswer(1, heard, skipped)}
           >
             Skip
           </button>
@@ -252,7 +253,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
             disabled={isSpeaking}
             listenMode={settings.autoListen ? 'auto' : 'hold'}
           />
-          <button className="dont-know-btn" onClick={() => applyResult(false, '')} aria-label="Don't know">
+          <button className="dont-know-btn" onClick={() => { setSkipped(true); applyResult(false, '') }} aria-label="Don't know">
             ?
           </button>
         </div>

--- a/src/components/FlashcardMode4.tsx
+++ b/src/components/FlashcardMode4.tsx
@@ -216,7 +216,7 @@ export function FlashcardMode4({ card, cardType, onAnswer }: Props) {
         manualGrading={settings.manualGrading}
         onOverrideCorrect={() => overrideGrade(4)}
         onOverrideIncorrect={() => overrideGrade(1)}
-        reportUrl={buildReportUrl(card)}
+        reportUrl={buildReportUrl(card, { heard, skipped })}
       />
 
       {correctionPhase && correctionResult !== 'correct' && (

--- a/src/components/PreviousResult.tsx
+++ b/src/components/PreviousResult.tsx
@@ -56,7 +56,10 @@ export function PreviousResult({ data, manualGrading, onOverride }: Props) {
       )}
       <a
         className="report-mistake-link report-mistake-compact"
-        href={buildReportUrl({ japanese: data.japanese, kana: data.kana, english: data.english } as Word)}
+        href={buildReportUrl(
+          { japanese: data.japanese, kana: data.kana, english: data.english } as Word,
+          { heard: data.heard, skipped: data.skipped }
+        )}
         target="_blank"
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}

--- a/src/components/PreviousResult.tsx
+++ b/src/components/PreviousResult.tsx
@@ -7,6 +7,7 @@ export interface PreviousResultData {
   english: string[]
   result: 'correct' | 'incorrect'
   heard: string
+  skipped: boolean
   mode: 1 | 4
 }
 
@@ -30,9 +31,11 @@ export function PreviousResult({ data, manualGrading, onOverride }: Props) {
           {' → '}
           {data.mode === 1 ? data.japanese : primaryEnglish}
         </span>
-        {data.heard && (
+        {data.skipped ? (
+          <span className="prev-result-heard">Skipped (didn't know)</span>
+        ) : data.heard ? (
           <span className="prev-result-heard">Heard: "{data.heard}"</span>
-        )}
+        ) : null}
       </div>
 
       {manualGrading && !isCorrect && (

--- a/src/pages/StudyPage.tsx
+++ b/src/pages/StudyPage.tsx
@@ -35,7 +35,7 @@ export function StudyPage() {
       : null
 
   const handleAnswer = useCallback(
-    (quality: number, heard: string) => {
+    (quality: number, heard: string, skipped: boolean) => {
       const existing = cardStates[card.kana]
       const updated = applyReview(existing, quality)
       applyCardReview(card.kana, updated)
@@ -46,6 +46,7 @@ export function StudyPage() {
         english: card.english,
         result: quality >= 3 ? 'correct' : 'incorrect',
         heard,
+        skipped,
         mode,
       })
       setLastShownId(card.kana)

--- a/src/utils/reportUrl.ts
+++ b/src/utils/reportUrl.ts
@@ -2,13 +2,25 @@ import type { Word } from '../types'
 
 const REPO_URL = 'https://github.com/meesvandongen/japanese-learning'
 
-export function buildReportUrl(word: Word): string {
+interface FeedbackInfo {
+  heard?: string
+  skipped?: boolean
+}
+
+export function buildReportUrl(word: Word, feedback?: FeedbackInfo): string {
   const title = `Vocab mistake: ${word.japanese} (${word.kana}) – ${word.english.join(', ')}`
   const body = [
     `**Word:** ${word.japanese}`,
     `**Reading:** ${word.kana}`,
     `**English:** ${word.english.join(', ')}`,
     word.hint ? `**Hint:** ${word.hint}` : '',
+    '',
+    '**User response**',
+    feedback?.skipped
+      ? 'Skipped (pressed "I don\'t know")'
+      : feedback?.heard
+        ? `Speech recognized: "${feedback.heard}"`
+        : 'No speech input',
     '',
     '**What is wrong?**',
     '',


### PR DESCRIPTION
Add a `skipped` boolean to PreviousResultData that distinguishes
when the user pressed the "?" (don't know) button vs gave an
incorrect speech answer. The STT transcript (`heard`) was already
passed through but is now surfaced alongside the skip indicator
in the previous-result banner.

https://claude.ai/code/session_01VMbVJggDWo5MgVfXqnE4bT